### PR TITLE
Remove JWT_AUTH check from settings

### DIFF
--- a/kerrokantasi/settings/__init__.py
+++ b/kerrokantasi/settings/__init__.py
@@ -5,9 +5,6 @@ settings = get_settings(base)
 load_local_settings(settings, "local_settings")
 load_secret_key(settings)
 
-if not settings["DEBUG"] and settings["JWT_AUTH"]["JWT_SECRET_KEY"] == "kerrokantasi":
-    raise ValueError("Refusing to run out of DEBUG mode with insecure JWT secret key.")
-
 settings['CKEDITOR_CONFIGS'] = {
     'default': {
         'stylesSet': [


### PR DESCRIPTION
JWT settings has been removed in OpenID change and currently there isn't use for this.