### PR TITLE
Added commenter email to api and hearing report

### DIFF
--- a/democracy/tests/test_comment.py
+++ b/democracy/tests/test_comment.py
@@ -778,6 +778,28 @@ def test_get_section_comment_creator_name_when_posted_by_registered_user(admin_a
 
 
 @pytest.mark.django_db
+def test_get_section_comment_creator_email_property_without_authorization(john_doe_api_client, default_hearing):
+    section = default_hearing.sections.first()
+    url = get_hearing_detail_url(default_hearing.id, 'sections/%s/comments' % section.id)
+    response = john_doe_api_client.get(url)
+    data = get_data_from_response(response, 200)
+    # check no section comment has creator_email when not authorized
+    for comment in data:
+        assert not "creator_email" in comment
+
+
+@pytest.mark.django_db
+def test_get_section_comment_creator_email_property_with_authorization(admin_api_client, default_hearing):
+    section = default_hearing.sections.first()
+    url = get_hearing_detail_url(default_hearing.id, 'sections/%s/comments' % section.id)
+    response = admin_api_client.get(url)
+    data = get_data_from_response(response, 200)
+    # check all section comments have creator_email when authorized
+    for comment in data:
+        assert "creator_email" in comment
+
+
+@pytest.mark.django_db
 def test_n_comments_updates(admin_user, default_hearing):
     section = default_hearing.get_main_section()
     assert Hearing.objects.get(pk=default_hearing.pk).n_comments == 9

--- a/democracy/views/hearing_report.py
+++ b/democracy/views/hearing_report.py
@@ -85,13 +85,14 @@ class HearingReport(object):
         section_worksheet = self.xlsdoc.add_worksheet(re.sub(r"\W+|_", " ", section_name[:31]))
         section_worksheet.set_landscape()
         section_worksheet.set_column('A:A', 50)
-        section_worksheet.set_column('B:B', 15)
-        section_worksheet.set_column('C:C', 10)
-        section_worksheet.set_column('D:D', 5)
-        section_worksheet.set_column('E:E', 50)
-        section_worksheet.set_column('F:F', 200)
-        section_worksheet.set_column('G:G', 100)
+        section_worksheet.set_column('B:B', 20)
+        section_worksheet.set_column('C:C', 15)
+        section_worksheet.set_column('D:D', 10)
+        section_worksheet.set_column('E:E', 5)
+        section_worksheet.set_column('F:F', 50)
+        section_worksheet.set_column('G:G', 200)
         section_worksheet.set_column('H:H', 100)
+        section_worksheet.set_column('I:I', 100)
 
         # add section title
         self.section_worksheet_active_row = 0
@@ -112,9 +113,9 @@ class HearingReport(object):
 
     def add_section_comments(self, section, section_worksheet):
         '''
-        Author  |  Content        | Created | Votes | Label   | Map comment        | Geojson      | Images
-        "name"  |  "comment text" | "date"  | num   | "label" | "map comment text" | "geo data"   | "url"
-        "name"  |  "comment text" | "date"  | num   | "label" | "map comment text" | "geo data"   | "url"
+        Author  |  Email  |     Content     | Created | Votes | Label   | Map comment        | Geojson      | Images
+        "name"  | "email" |  "comment text" | "date"  | num   | "label" | "map comment text" | "geo data"   | "url"
+        "name"  | "email" |  "comment text" | "date"  | num   | "label" | "map comment text" | "geo data"   | "url"
         '''
 
         # add comments title
@@ -129,6 +130,11 @@ class HearingReport(object):
         # include Author only if requesting user is staff
         if(self.context['request'].user.is_staff or self.context['request'].user.is_superuser):
             section_worksheet.write(row, col_index, 'Author', self.format_bold)
+            col_index += 1
+
+        # include Email only if requesting user is staff
+        if(self.context['request'].user.is_staff or self.context['request'].user.is_superuser):
+            section_worksheet.write(row, col_index, 'Email', self.format_bold)
             col_index += 1
 
         section_worksheet.write(row, col_index, 'Content', self.format_bold)
@@ -155,7 +161,7 @@ class HearingReport(object):
 
     def add_comment_row(self, comment, section_worksheet):
         '''
-        "name" | "comment text" | "date"  | num   | "label" | "map comment text" | "geo data"   | "url"
+        "name" | "email" | "comment text" | "date"  | num   | "label" | "map comment text" | "geo data"   | "url"
         '''
         row = self.section_worksheet_active_row
         col_index = 0
@@ -166,6 +172,12 @@ class HearingReport(object):
             section_worksheet.write(row, col_index, self.mitigate_cell_formula_injection(name))
             col_index += 1
         # section_worksheet.write(row, 0, comment['author_name'])
+
+        # include Email only if requesting user is staff
+        if(self.context['request'].user.is_staff or self.context['request'].user.is_superuser):
+            email = comment.get('creator_email')
+            section_worksheet.write(row, col_index, self.mitigate_cell_formula_injection(email))
+            col_index += 1
         # add content
         section_worksheet.write(row, col_index, self.mitigate_cell_formula_injection(comment['content']))
         col_index += 1

--- a/democracy/views/section_comment.py
+++ b/democracy/views/section_comment.py
@@ -130,11 +130,12 @@ class SectionCommentSerializer(BaseCommentSerializer):
     images = CommentImageSerializer(many=True, read_only=True)
     answers = serializers.SerializerMethodField()
     creator_name = serializers.SerializerMethodField()
+    creator_email = serializers.SerializerMethodField()
 
     class Meta:
         model = SectionComment
         fields = ['section', 'language_code', 'answers', 'comment',
-                  'comments', 'n_comments', 'pinned', 'reply_to', 'creator_name'] + COMMENT_FIELDS
+                  'comments', 'n_comments', 'pinned', 'reply_to', 'creator_name', 'creator_email'] + COMMENT_FIELDS
 
     def get_answers(self, obj):
         polls_by_id = {}
@@ -154,10 +155,17 @@ class SectionCommentSerializer(BaseCommentSerializer):
         else:
             return 'Anonymous'
 
+    def get_creator_email(self, obj):
+        if obj.created_by and not obj.created_by.is_anonymous:
+            return obj.created_by.email
+        else:
+            return ''
+
     def to_representation(self, instance):
         data = super(SectionCommentSerializer, self).to_representation(instance)
         if not self.context['request'].user.is_staff and not self.context['request'].user.is_superuser:
             del data['creator_name']
+            del data['creator_email']
 
         return data
 


### PR DESCRIPTION
Staff and superusers can now see comment author's email in hearing report and the comment API. Commenter email field won't be included for other users.