### PR TITLE
hearing creators can now delete comments

### DIFF
--- a/democracy/tests/conftest.py
+++ b/democracy/tests/conftest.py
@@ -323,6 +323,28 @@ def john_smith_api_client(john_smith):
 
 
 @pytest.fixture()
+def steve_staff(default_organization):
+    """
+    Steve Staff is registered user working for an organization that has staff rights to django.
+    """
+    user = get_user_model().objects.filter(username="steve_staff").first()
+    if not user:  # pragma: no branch
+        user = get_user_model().objects.create_user("steve_staff", "staff_steve@example.com", password="password")
+        user.is_staff = True
+        user.admin_organizations.add(default_organization)
+    return user
+
+@pytest.fixture()
+def steve_staff_api_client(steve_staff):
+    """
+    Steve Staff is a registered user working for an organization that has staff rights to django; this is his API client.
+    """
+    api_client = APIClient()
+    api_client.force_authenticate(user=steve_staff)
+    api_client.user = steve_staff
+    return api_client
+
+@pytest.fixture()
 def admin_api_client(admin_user):
     api_client = APIClient()
     api_client.force_authenticate(user=admin_user)

--- a/democracy/views/comment.py
+++ b/democracy/views/comment.py
@@ -9,6 +9,8 @@ from rest_framework.settings import api_settings
 from reversion import revisions
 
 from democracy.models.comment import BaseComment
+from democracy.models.section import Section
+from democracy.models.hearing import Hearing
 from democracy.views.base import AdminsSeeUnpublishedMixin, CreatedBySerializer
 from democracy.views.utils import GeoJSONField, AbstractSerializerMixin
 from democracy.renderers import GeoJSONRenderer
@@ -36,6 +38,21 @@ class BaseCommentSerializer(AbstractSerializerMixin, CreatedBySerializer, serial
 
     def get_can_edit(self, obj):
         request = self.context.get('request', None)
+        '''
+        Users that have is_staff and that are the creators of the hearing can edit/delete comments
+        as long as the hearing is commentable.
+        '''
+        # If user.is_staff then we check if user is also the creator of the hearing
+        if request.user.is_staff and Section.objects.get(id=obj.section_id) is not None:
+            specific_section = Section.objects.get(id=obj.section_id)
+            specific_hearing = Hearing.objects.get(id=specific_section.hearing_id)
+            if request.user.id == specific_hearing.created_by_id:
+                try:
+                    obj.parent.check_commenting(request)
+                except ValidationError:
+                    return False
+                return True
+
         if request:
             return obj.can_edit(request)
         return False
@@ -125,6 +142,24 @@ class BaseCommentViewSet(AdminsSeeUnpublishedMixin, viewsets.ModelViewSet):
                 {'status': force_text(verr), 'code': verr.code},
                 status=status.HTTP_403_FORBIDDEN
             )
+    
+    def _check_hearing_creator(self, request):
+        '''
+        Returns boolean based on if request.user has is_staff rights, is the creator of the hearing
+        and if the hearing is commentable.
+        '''
+        obj = self.get_object()
+        if request.user.is_staff and Section.objects.get(id=obj.section_id) is not None:
+            specific_section = Section.objects.get(id=obj.section_id)
+            specific_hearing = Hearing.objects.get(id=specific_section.hearing_id)
+            if request.user.id == specific_hearing.created_by_id:
+                try:
+                    obj.parent.check_commenting(request)
+                except ValidationError:
+                    return False
+                return True
+        return False
+
 
     def create(self, request, *args, **kwargs):
         resp = self._check_may_comment(request)
@@ -149,9 +184,13 @@ class BaseCommentViewSet(AdminsSeeUnpublishedMixin, viewsets.ModelViewSet):
             return resp
 
         instance = self.get_object()
-        if self.request.user != instance.created_by:
+        '''
+        Comment editing is only possible if the comment is created by user OR
+        if the user has is_staff rights AND is the creator of the hearing that this comment is in.
+        '''
+        if not self._check_hearing_creator(request) and self.request.user != instance.created_by:
             return response.Response(
-                {'status': 'You may not edit a comment not owned by you'},
+                {'status': 'You do not have sufficient rights to edit a comment not owned by you.'},
                 status=status.HTTP_403_FORBIDDEN
             )
         if request.user.is_authenticated and 'author_name' in request.data:
@@ -187,10 +226,13 @@ class BaseCommentViewSet(AdminsSeeUnpublishedMixin, viewsets.ModelViewSet):
             return resp
 
         instance = self.get_object()
-
-        if self.request.user != instance.created_by:
+        '''
+        Comment deletion is only possible if the comment is created by user OR
+        if the user has is_staff rights AND is the creator of the hearing that this comment is in.
+        '''
+        if not self._check_hearing_creator(request) and self.request.user != instance.created_by:
             return response.Response(
-                {'status': 'You may not delete a comment not owned by you'},
+                {'status': 'You do not have sufficient rights to delete a comment not owned by you.'},
                 status=status.HTTP_403_FORBIDDEN
             )
 


### PR DESCRIPTION
Changes:
- A user is now able to delete and modify the comments of a hearing as long as `user.is_staff == True` and the hearing was created by the user.
- Added tests

[This is the trello card for this issue.](https://trello.com/c/pnhhQtV1/66-oman-kommentin-poistaminen)