### PR TITLE
hearing filter by follow and user comment changes

### DIFF
--- a/democracy/tests/test_comment.py
+++ b/democracy/tests/test_comment.py
@@ -1254,3 +1254,68 @@ def test_comment_ordering(api_client, ordering, expected_order, default_hearing)
 
     n_votes_list = [comment['n_votes'] for comment in results]
     assert n_votes_list == expected_order
+
+
+@pytest.mark.django_db
+def test_get_comments_created_by_user(john_doe_api_client, jane_doe_api_client, get_comments_url_and_data):
+    hearings = []
+    sections = []
+    # Create 3 hearings with a section that can be commented.
+    for i in range(3):
+        hearings.append(
+            Hearing.objects.create(
+                title='Test hearing title %s' % (i + 1),
+                open_at=now() - datetime.timedelta(days=1),
+                close_at=now() + datetime.timedelta(days=1)
+            )
+        )
+        sections.append(
+            Section.objects.create(
+                title='Hearing %s Section to comment' % (i + 1),
+                hearing=hearings[i],
+                commenting=Commenting.OPEN,
+                type=SectionType.objects.get(identifier=InitialSectionType.PART)
+            )
+        )
+    
+    # John comments on each hearing.
+    expected_john_comment_content = []
+    for i in range(len(hearings)):
+        url, data = get_comments_url_and_data(hearings[i], sections[i])
+        comment_data = get_comment_data(section=sections[i].pk, author_name='John', content='Comment for Hearing %s' % (i + 1))
+        expected_john_comment_content.insert(0, 'Comment for Hearing %s' % (i + 1))
+        john_doe_api_client.post(url, data=comment_data)
+
+
+    # Jane comments on the first hearing.
+    comment_data = get_comment_data(section=sections[0].pk, author_name='Jane', content='Jane created this comment')
+    jane_doe_api_client.post(url, data=comment_data)
+
+    # John fetches all comments he has made.
+    response = john_doe_api_client.get(root_list_url, data={"created_by": "me"})
+    assert response.status_code == 200
+    data = get_data_from_response(response)
+    
+    assert len(data['results']) == len(hearings)
+
+    # Hearing slug values are added to a list as they are used to test that the comments belong to correct hearings.
+    expected_slug_values = []
+    for i in range(len(hearings)):
+        expected_slug_values.insert(0, hearings[i].slug)
+
+
+    # Each comment has the expected content and hearing slug.
+    for i in range(len(data['results'])):
+        assert data['results'][i]['content'] == expected_john_comment_content[i]
+        assert data['results'][i]['hearing_data']['slug'] == expected_slug_values[i]
+
+    # Jane fetches all comments she has made.
+    response = jane_doe_api_client.get(root_list_url, data={"created_by": "me"})
+    assert response.status_code == 200
+    data = get_data_from_response(response)
+    
+    assert len(data['results']) == 1
+    assert data['results'][0]['content'] == 'Jane created this comment'
+
+
+    

--- a/democracy/tests/test_hearing.py
+++ b/democracy/tests/test_hearing.py
@@ -419,6 +419,42 @@ def test_filter_hearings_created_by_me(api_client, john_smith_api_client, jane_d
     assert len(stark_data['results']) == 1
     
     
+@pytest.mark.django_db
+def test_filter_hearings_by_following(john_doe_api_client):
+    # We create three hearings
+    first_hearing = Hearing.objects.create(title='First Hearing')
+    second_hearing = Hearing.objects.create(title='Second Hearing')
+    third_hearing = Hearing.objects.create(title='Third Hearing')
+
+    # John starts following the first hearing
+    response = john_doe_api_client.post(get_hearing_detail_url(first_hearing.id, 'follow'))
+    assert response.status_code == 201
+    # John fetches hearings that he follows, only 1 hearing is returned.
+    response = john_doe_api_client.get(list_endpoint, data={"following": True})
+    data = get_data_from_response(response)
+    assert data['results'][0]['title'][default_lang_code] == first_hearing.title
+    assert len(data['results']) == 1
+
+    # John starts following the second hearing
+    response = john_doe_api_client.post(get_hearing_detail_url(second_hearing.id, 'follow'))
+    assert response.status_code == 201
+    # John fetches hearings that he follows, 2 hearings are returned.
+    response = john_doe_api_client.get(list_endpoint, data={"following": True})
+    data = get_data_from_response(response)
+    assert data['results'][0]['title'][default_lang_code] == second_hearing.title
+    assert data['results'][1]['title'][default_lang_code] == first_hearing.title
+    assert len(data['results']) == 2
+
+    # John starts following the third hearing
+    response = john_doe_api_client.post(get_hearing_detail_url(third_hearing.id, 'follow'))
+    assert response.status_code == 201
+    # John fetches hearings that he follows, 3 hearings are returned.
+    response = john_doe_api_client.get(list_endpoint, data={"following": True})
+    data = get_data_from_response(response)
+    assert data['results'][0]['title'][default_lang_code] == third_hearing.title
+    assert data['results'][1]['title'][default_lang_code] == second_hearing.title
+    assert data['results'][2]['title'][default_lang_code] == first_hearing.title
+    assert len(data['results']) == 3
 
 
 @pytest.mark.parametrize('plugin_fullscreen', [

--- a/democracy/views/hearing.py
+++ b/democracy/views/hearing.py
@@ -413,6 +413,10 @@ class HearingViewSet(AdminsSeeUnpublishedMixin, viewsets.ModelViewSet):
         next_closing = self.request.query_params.get('next_closing', None)
         open = self.request.query_params.get('open', None)
         created_by = self.request.query_params.get('created_by', None)
+        following = self.request.query_params.get('following', None)
+
+        if following is not None and self.request.user:
+            queryset = queryset.filter(followers=self.request.user)
 
         if created_by is not None and self.request.user:
             if created_by.lower() == 'me':


### PR DESCRIPTION
These changes are related to the new user profile page.
Changes:
- section_comment.py 
Added a `hearing_data` key that contains hearing data specific to the hearing that the comment was made to.
Comments can now be filtered to only return comments created by the user.
- hearing.py
Added `following` query param so the hearings can be filtered according the if user is following them.