### PR TITLE
Changed powerpoint reports to omit closure info

### DIFF
--- a/democracy/views/reports_v2/hearing_report_powerpoint.py
+++ b/democracy/views/reports_v2/hearing_report_powerpoint.py
@@ -11,6 +11,7 @@ from pptx import Presentation
 from pptx.chart.data import CategoryChartData
 from pptx.enum.chart import XL_CHART_TYPE
 from pptx.util import Inches
+from democracy.enums import InitialSectionType
 from democracy.models.section import SectionComment
 
 from democracy.views.reports_v2.utils import (get_default_translation,
@@ -188,7 +189,8 @@ class HearingReportPowerPoint():
     def _get_pptx(self):
         sections = self.json['sections']
         for section in sections:
-            self._add_section(section)
+            if section['type'] != InitialSectionType.CLOSURE_INFO:
+                self._add_section(section)
 
         self.prs.save(self.buffer)
         return self.buffer.getvalue()


### PR DESCRIPTION
# Hearing PowerPoint report omits closure info

## Changed PowerPoint reports to omit closure info section

### [Related Trello card](https://trello.com/c/goIyCBG4)

-----------------------------------------------------------------------------------------------
### Breakdown:

#### PowerPoint report omit closure info
 1. democracy/views/reports_v2/hearing_report_powerpoint.py
     * filtered closure info sections from report slides