### PR TITLE
Changed min python version from 3.6 to 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ services:
 
 language: python
 python:
-  - '3.6'
   - '3.7'
   - '3.8'
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ This applies to both development and simple production scale. Note that you won'
 
 ### Prerequisites
 
-* Python 3.6 or later
+* Python 3.7 or later
 * PostgreSQL with PostGIS extension
 * Application server implementing WSGI interface (fe. Gunicorn or uwsgi), not needed for development
 


### PR DESCRIPTION
Python 3.6 reached end-of-life. Updated min python version requirement to be 3.7

Changes:
- updated readme python min version to 3.7
- removed python 3.6 from Travis config