### PR TITLE
Fixed ability to add attachments to new hearings

### DIFF
--- a/democracy/views/section.py
+++ b/democracy/views/section.py
@@ -297,7 +297,7 @@ class SectionCreateUpdateSerializer(serializers.ModelSerializer, TranslatableSer
 
             if pk:
                 try:
-                    if self.instance is not None:
+                    if self.instance is not None or self.context['request'].data.get('isNew'):
                         # only allow orphan files or files within this section already
                         file = SectionFile.objects.filter(Q(section=None) | (Q(section=self.instance))).get(pk=pk)
                     else:  # Creating a copy of the hearing


### PR DESCRIPTION
# Fixed ability to add attachments to new hearings

## Attachments caused an error in hearing creation. This fix allows attachments to be included in hearing creation.

### [Related Trello card](https://trello.com/c/cjCwwIhB)

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Attachment fix
 1. democracy/views/section.py
     * added logic to differentiate new hearings from cloned hearings